### PR TITLE
fixes

### DIFF
--- a/LiveCode.sublime-syntax
+++ b/LiveCode.sublime-syntax
@@ -19,6 +19,9 @@ contexts:
       captures:
         1: keyword.script.name.livecode
       push: [root, pop_after_string]
+    - include: comment
+    - match: '(?=\S)'
+      push: root
 
   pop_after_string:
     - include: string
@@ -421,7 +424,7 @@ contexts:
       pop: true
 
   put:
-    - match: '\s*(put)\s+'
+    - match: '\s*\b(put)\s+'
       captures:
         1: keyword.other.livecode
       push:

--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List</string>
+	<key>scope</key>
+	<string>entity.name.function.end.livecode, entity.name.function.property.end.livecode, entity.name.function.handler.end.livecode</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>0</integer>
+	</dict>
+</dict>
+</plist>

--- a/syntax_test_LiveCode_no_script.livecodescript
+++ b/syntax_test_LiveCode_no_script.livecodescript
@@ -1,0 +1,18 @@
+-- SYNTAX TEST "Packages/LiveCode/LiveCode.sublime-syntax"
+
+global gGlobalVar # no variable assignemnt allowed for globals
+-- <- storage.modifier.livecode
+--^^^^ storage.modifier.livecode
+--     ^^^^^^^^^^ variable.other.livecode
+--    ^ - storage - variable
+--               ^ - variable - comment
+--                ^ punctuation.definition.comment.livecode
+--                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.hash.livecode
+
+
+function myFunction
+  return tOutput
+--           ^^^ - keyword
+end myFunction
+--^ keyword.control.function.end.livecode
+--  ^^^^^^^^^^ entity.name.function.end.livecode


### PR DESCRIPTION
- make `script "name"` optional
- only match `put` if it is not part of another word
- don't show methods in Goto Symbol twice