### PR TITLE
Support compound lines that continue with an if statement

### DIFF
--- a/LiveCode.sublime-syntax
+++ b/LiveCode.sublime-syntax
@@ -256,9 +256,10 @@ contexts:
       pop: true
 
   control:
-    - match: '(?i)^\s*(if)\s+'
+    - match: '(?i)(^|;)\s*(if)\s+'
       captures:
-        1: keyword.control.flow.livecode
+        1: punctuation.terminator.livecode
+        2: keyword.control.flow.livecode
       push: then_could_be_block_or_single_line
     - match: '(?i)^\s*(switch)\s+'
       captures:

--- a/syntax_test_LiveCode.livecodescript
+++ b/syntax_test_LiveCode.livecodescript
@@ -102,8 +102,8 @@ local var4, var5, var6 -- comment
 --                     ^^^^^^^^^^^ comment
 
 on libraryStack
--- <- keyword.control.function.handler.begin.livecode
--- ^^^^^^^^^^^^ entity.name.function.handler.begin.livecode
+-- <- keyword.control.function.begin.livecode
+-- ^^^^^^^^^^^^ entity.name.function.begin.livecode
 --^ - entity - keyword
 --             ^ - entity
 -- <- meta.function.livecode
@@ -142,8 +142,8 @@ on libraryStack
 --                                                                         ^ - variable
   
 end libraryStack
--- <- keyword.control.function.handler.end.livecode
---  ^^^^^^^^^^^^ entity.name.function.handler.end.livecode
+-- <- keyword.control.function.end.livecode
+--  ^^^^^^^^^^^^ entity.name.function.end.livecode
 --              ^ - keyword - entity - meta
 
 setProp uCustomProp pValue
@@ -590,3 +590,12 @@ end myProp
 on doSomethingElse
 
 end doSomethingElse
+
+ask "Do you want gravy?"; if it is "OK" then putGravyOnPotatoes # compound line
+--                      ^ punctuation.terminator
+--                        ^^ keyword.control.flow
+--                           ^^ keyword.other
+--                              ^^ keyword.operator
+--                                 ^^^^ string.quoted.double
+--                                      ^^^^ keyword.control.flow
+--                                                              ^^^^^^^^^^^^^^^^ comment.line


### PR DESCRIPTION
This is a concrete fix for issue #11. If there are more statements that can be compounded, a similar change can be made for the others.
This also fixes the syntax tests which were failing.