### PR TITLE
[[ Bug ]] Fix repeat with syntax error

### DIFF
--- a/LiveCode Builder.sublime-syntax
+++ b/LiveCode Builder.sublime-syntax
@@ -320,7 +320,7 @@ contexts:
         - match: '{{identifier}}'
           scope: variable.other.livecodebuilder
           set:
-            - match: '='
+            - match: 'from'
               scope: keyword.operator.assignment.livecodebuilder
               set: inside_repeat
             - match: '$\n?'


### PR DESCRIPTION
This patch fixes the repeat with syntax error. In LCB the syntax is
`repeat with <var> from` rather than `=`.